### PR TITLE
DQC config update

### DIFF
--- a/grumphp.yml
+++ b/grumphp.yml
@@ -37,10 +37,10 @@ grumphp:
         - .github
         - .gitlab
         - .ddev
-        - /config/
-        - /drush/
+        - /config
+        - /drush
         - /web/robots.txt
-        - /web/sites/default/
+        - /web/sites/default
         - bower_components
         - node_modules
         - /vendor
@@ -71,10 +71,10 @@ grumphp:
         - .github
         - .gitlab
         - .ddev
-        - /config/
-        - /drush/
+        - /config
+        - /drush
         - /web/robots.txt
-        - /web/sites/default/
+        - /web/sites/default
         - bower_components
         - node_modules
         - /vendor

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -66,7 +66,7 @@ grumphp:
         - module
         - theme
     phpstan:
-      configuration: phpstan.neon.dist
+      configuration: phpstan.neon
       ignore_patterns:
         - .github
         - .gitlab

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -12,7 +12,24 @@
   <rule ref="rulesets/design.xml">
     <exclude name="CouplingBetweenObjects"/>
   </rule>
-  <rule ref="rulesets/naming.xml"/>
+
+  <rule ref="rulesets/naming.xml">
+    <exclude name="ShortVariable"/>
+    <exclude name="LongVariable"/>
+  </rule>
+
+  <rule ref="rulesets/naming.xml/ShortVariable">
+    <properties>
+        <property name="exceptions" value="id,op"/>
+    </properties>
+  </rule>
+
+  <rule ref="rulesets/naming.xml/LongVariable">
+    <properties>
+        <property name="maximum" value="30"/>
+    </properties>
+  </rule>
+
   <rule ref="rulesets/unusedcode.xml">
     <exclude name="UnusedFormalParameter"/>
   </rule>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+includes:
+  - vendor/mglaman/phpstan-drupal/extension.neon
+  - vendor/mglaman/phpstan-drupal/rules.neon
+parameters:
+  customRulesetUsed: true


### PR DESCRIPTION
This PR updates the latest changes from DQC to contrib-tracker

1. Copy latest changes for phpmd
2. create phpstan.neon so we can use it in CI/CD as *.dist files are ignored in git.
3. remove slashes at end for ignore_patterns paths.

@hussainweb Do you think we should add Dist file to git also so if modification is not required, we do not need to create a copy of it. else for CI/CD we will require to create a copy.  