### PR TITLE
Use GrumPHP within CI pipeline as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,22 +33,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Get Cache Directories
-        id: cache-dir
-        run: echo "npm-dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
-        with:
-          path: |
-            **/node_modules
-            ${{ steps.cache-dir.outputs.npm-dir }}
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
-
       - name: Frontend Code Quality
         run: |
           cd web/themes/custom/contribtracker
-          npm install
+          npm ci
           npm run lint
 
 
@@ -69,14 +57,6 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            **/node_modules
-            ${{ steps.cache-dir.outputs.npm-dir }}
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
 
       - name: Setup DDEV
         uses: ddev/github-action-setup-ddev@v1
@@ -99,7 +79,7 @@ jobs:
       - name: Build front-end
         run: |
           cd web/themes/custom/contribtracker
-          npm install
+          npm ci
           gulp
 
       - name: Run phpstan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Frontend Code Quality
         run: |
           cd web/themes/custom/contribtracker
-          npm ci
+          npm install
           npm run lint
 
 
@@ -99,7 +99,7 @@ jobs:
       - name: Build front-end
         run: |
           cd web/themes/custom/contribtracker
-          npm ci
+          npm install
           gulp
 
       - name: Run phpstan
@@ -159,7 +159,7 @@ jobs:
           ./vendor/bin/drush deploy -y
           ./vendor/bin/drush upwd ct-admin "ct-admin"
           cd web/themes/custom/contribtracker
-          npm ci --cache $CI_PROJECT_DIR/.npm --prefer-offline
+          npm install --cache $CI_PROJECT_DIR/.npm --prefer-offline
           npm run build
           npm run vr
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
           npm ci
           gulp
 
+      - name: Run phpstan
+        run: ddev php ./vendor/bin/grumphp run --tasks=phpstan
+
       - name: Test
         run: |
           ddev phpunit --testsuite unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,22 @@ jobs:
       - name: Run code quality check
         run: grumphp run --testsuite=code_quality
 
-
   frontend_codequality:
     runs-on: ubuntu-latest
     container: node:lts
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+
+      - name: Get Cache Directories
+        id: cache-dir
+        run: echo "npm-dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.cache-dir.outputs.npm-dir }}
+          key: ${{ runner.os }}-npm-fec-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-fec-
 
       - name: Frontend Code Quality
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
 
       - name: Set the platform.sh token
         run: |
-          ddev config global --instrumentation-opt-in=false
           ddev config global --web-environment-add="PLATFORMSH_CLI_TOKEN=${{ secrets.PLATFORMSH_CLI_TOKEN }}"
           ddev start
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,8 @@ jobs:
       - name: Get Cache Directories
         id: cache-dir
         run: |
-          echo "::set-output name=composer-dir::$(composer config cache-files-dir)"
-          echo "::set-output name=npm-dir::$(npm config get cache)"
+          echo "composer-dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+          echo "npm-dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: ${{ steps.cache-dir.outputs.composer-dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,24 @@ concurrency:
 jobs:
   drupal_codequality:
     runs-on: ubuntu-latest
-    container: hussainweb/drupalqa
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      # Run using testsuites
-      - name: Run linters
-        run: grumphp run --testsuite=linters --no-interaction
-      - name: Run code quality check
-        run: grumphp run --testsuite=code_quality --no-interaction
+      - name: Drupal Code Quality
+        uses: hussainweb/drupalqa-action@v2
+        id: drupalqa
+        with:
+          php-version: 8.2
+          checks: |
+            grumphp:
+              tasks:
+                - phplint
+                - yamllint
+                - jsonlint
+                - phpcs
+                - phpmd
+                - twigcs
 
   frontend_codequality:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,14 +50,20 @@ jobs:
       - name: Get Cache Directories
         id: cache-dir
         run: |
-          echo "::set-output name=composer-dir::$(composer config cache-files-dir)"
-          echo "::set-output name=npm-dir::$(npm config get cache)"
+          echo "composer-dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+          echo "npm-dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
           path: ${{ steps.cache-dir.outputs.composer-dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.cache-dir.outputs.npm-dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: Setup DDEV
         uses: ddev/github-action-setup-ddev@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,72 @@ jobs:
           ddev phpunit --testsuite unit
           ddev phpunit --bootstrap=./vendor/weitzman/drupal-test-traits/src/bootstrap-fast.php --configuration ./phpunit.xml --testsuite existing-site
 
+
+  frontend_vr:
+    permissions:
+      packages: read
+      contents: read
+    needs: [frontend_codequality]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    container: skippednote/drupal-cypress:1.0.6
+    env:
+      # For Cypress.
+      CYPRESS_ADMIN_USERNAME: ct-admin
+      CYPRESS_ADMIN_PASSWORD: ct-admin
+    services:
+      mariadb:
+        image: ghcr.io/contrib-tracker/backend-db:main
+        env:
+          ALLOW_EMPTY_PASSWORD: "yes"
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Get Cache Directories
+        id: cache-dir
+        run: |
+          echo "composer-dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+          echo "npm-dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.cache-dir.outputs.composer-dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.cache-dir.outputs.npm-dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Test
+        run: |
+          ./.github/ci.sh
+          composer install -o --no-progress
+          ./vendor/bin/drush deploy -y
+          ./vendor/bin/drush upwd ct-admin "ct-admin"
+          cd web/themes/custom/contribtracker
+          npm ci --cache $CI_PROJECT_DIR/.npm --prefer-offline
+          npm run build
+          npm run vr
+
+      - name: Archive Cypress recordings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-recordings
+          path: |
+            web/themes/custom/contribtracker/cypress/screenshots
+            web/themes/custom/contribtracker/cypress/videos
+          retention-days: 3
+
   deploy:
     needs:
       - drupal_codequality
       - drupal_test
+      - frontend_vr
     runs-on: ubuntu-latest
     # Dependabot PR's can't access secrets, so we can't deploy.
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ steps.cache-dir.outputs.npm-dir }}
-          key: ${{ runner.os }}-npm-fec-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-npm-fec-
+            ${{ runner.os }}-npm-
 
       - name: Frontend Code Quality
         run: |
@@ -70,9 +70,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ steps.cache-dir.outputs.npm-dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-npm-
 
       - name: Setup DDEV
         uses: ddev/github-action-setup-ddev@v1
@@ -142,9 +142,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ steps.cache-dir.outputs.npm-dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('web/themes/custom/contribtracker/package-lock.json') }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-
+            ${{ runner.os }}-npm-
 
       - name: Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - cicd
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           ./vendor/bin/drush deploy -y
           ./vendor/bin/drush upwd ct-admin "ct-admin"
           cd web/themes/custom/contribtracker
-          npm install --cache $CI_PROJECT_DIR/.npm --prefer-offline
+          npm ci --cache $CI_PROJECT_DIR/.npm --prefer-offline
           npm run build
           npm run vr
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - cicd
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Set the platform.sh token
         run: |
+          ddev config global --instrumentation-opt-in=false
           ddev config global --web-environment-add="PLATFORMSH_CLI_TOKEN=${{ secrets.PLATFORMSH_CLI_TOKEN }}"
           ddev start
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,23 +15,16 @@ concurrency:
 jobs:
   drupal_codequality:
     runs-on: ubuntu-latest
+    container: hussainweb/drupalqa
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Drupal Code Quality
-        uses: hussainweb/drupalqa-action@v2
-        id: drupalqa
-        with:
-          php-version: 8.2
-          checks: |
-            phplint: {}
-            phpcs:
-              standard: phpcs.xml
-              ignore: /node_modules/
-            phpmd:
-              ruleset: phpmd.xml
-              suffixes: php
+      # Run using testsuites
+      - name: Run linters
+        run: grumphp run --testsuite=linters
+      - name: Run code quality check
+        run: grumphp run --testsuite=code_quality
 
 
   frontend_codequality:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,12 +123,10 @@ jobs:
             ${{ runner.os }}-composer-
       - uses: actions/cache@v4
         with:
-          path: |
-            **/node_modules
-            ${{ steps.cache-dir.outputs.npm-dir }}
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          path: ${{ steps.cache-dir.outputs.npm-dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-npm-
+            ${{ runner.os }}-node-
 
       - name: Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,72 +88,10 @@ jobs:
           ddev phpunit --testsuite unit
           ddev phpunit --bootstrap=./vendor/weitzman/drupal-test-traits/src/bootstrap-fast.php --configuration ./phpunit.xml --testsuite existing-site
 
-
-  frontend_vr:
-    permissions:
-      packages: read
-      contents: read
-    needs: [frontend_codequality]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    container: skippednote/drupal-cypress:1.0.6
-    env:
-      # For Cypress.
-      CYPRESS_ADMIN_USERNAME: ct-admin
-      CYPRESS_ADMIN_PASSWORD: ct-admin
-    services:
-      mariadb:
-        image: ghcr.io/contrib-tracker/backend-db:main
-        env:
-          ALLOW_EMPTY_PASSWORD: "yes"
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Get Cache Directories
-        id: cache-dir
-        run: |
-          echo "composer-dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-          echo "npm-dir=$(npm config get cache)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
-        with:
-          path: ${{ steps.cache-dir.outputs.composer-dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ steps.cache-dir.outputs.npm-dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Test
-        run: |
-          ./.github/ci.sh
-          composer install -o --no-progress
-          ./vendor/bin/drush deploy -y
-          ./vendor/bin/drush upwd ct-admin "ct-admin"
-          cd web/themes/custom/contribtracker
-          npm ci --cache $CI_PROJECT_DIR/.npm --prefer-offline
-          npm run build
-          npm run vr
-
-      - name: Archive Cypress recordings
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: cypress-recordings
-          path: |
-            web/themes/custom/contribtracker/cypress/screenshots
-            web/themes/custom/contribtracker/cypress/videos
-          retention-days: 3
-
   deploy:
     needs:
       - drupal_codequality
       - drupal_test
-      - frontend_vr
     runs-on: ubuntu-latest
     # Dependabot PR's can't access secrets, so we can't deploy.
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
         run: echo "npm-dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v4
         with:
-          path: ${{ steps.cache-dir.outputs.npm-dir }}
+          path: |
+            **/node_modules
+            ${{ steps.cache-dir.outputs.npm-dir }}
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
@@ -69,7 +71,9 @@ jobs:
             ${{ runner.os }}-composer-
       - uses: actions/cache@v4
         with:
-          path: ${{ steps.cache-dir.outputs.npm-dir }}
+          path: |
+            **/node_modules
+            ${{ steps.cache-dir.outputs.npm-dir }}
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
@@ -141,7 +145,9 @@ jobs:
             ${{ runner.os }}-composer-
       - uses: actions/cache@v4
         with:
-          path: ${{ steps.cache-dir.outputs.npm-dir }}
+          path: |
+            **/node_modules
+            ${{ steps.cache-dir.outputs.npm-dir }}
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
 
       # Run using testsuites
       - name: Run linters
-        run: grumphp run --testsuite=linters
+        run: grumphp run --testsuite=linters --no-interaction
       - name: Run code quality check
-        run: grumphp run --testsuite=code_quality
+        run: grumphp run --testsuite=code_quality --no-interaction
 
   frontend_codequality:
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
           gulp
 
       - name: Run phpstan
-        run: ddev php ./vendor/bin/grumphp run --tasks=phpstan
+        run: ddev php ./vendor/bin/grumphp run --tasks=phpstan --no-interaction
 
       - name: Test
         run: |

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -2,6 +2,17 @@ parameters:
   git_dir: .
   bin_dir: vendor/bin
 grumphp:
+  testsuites:
+    linters:
+      tasks:
+        - phplint
+        - yamllint
+        - jsonlint
+    code_quality:
+      tasks:
+        - phpcs
+        - phpmd
+        - twigcs
   ascii:
     failed: vendor/axelerant/drupal-quality-checker/resources/grumpy.txt
     succeeded: vendor/axelerant/drupal-quality-checker/resources/happy.txt


### PR DESCRIPTION
This PR contains the following changes

1. Run Code Quality check using GrumPHP
2. Fix some deprecation notices
3. add phpstan check

@hussainweb  I tried caching npm cache dir and node_modules dirs but `npm ci` always does a clean install so no impact on the time taken to install deps. Currently, it does not seem to be an option available in npm similar to `yarn install --immutable` which respects the node_modules dir and updates only when required. Maybe we can consider moving to yarn for performance improvement. What's your thought?