### PR TITLE
revert: partial change from #445

### DIFF
--- a/web/themes/custom/contribtracker/cypress.config.js
+++ b/web/themes/custom/contribtracker/cypress.config.js
@@ -2,9 +2,6 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    setupNodeEvents(on, config) {
-      // implement node event listeners here
-      baseUrl: 'https://contribtracker.ddev.site/'
-    },
+    baseUrl: 'https://contribtracker.ddev.site/',
   },
 });


### PR DESCRIPTION
this config breaks with Cypress 13. It fails to detect the baseUrl entirely. Whereas directly setting the `e2e.baseUrl` works with both Cypress 12 and 13.