### PR TITLE
run cypress on cli without XQuartz

### DIFF
--- a/.ddev/commands/cypress/cypress-run
+++ b/.ddev/commands/cypress/cypress-run
@@ -5,4 +5,4 @@
 ## Usage: cypress-run [arguments]
 ## Example: "ddev cypress-run --browser chrome"
 
-cypress run "$@"
+DISPLAY= cypress run "$@"


### PR DESCRIPTION
Execute `ddev cypress-run` without need of XQuartz