### PR TITLE
remove GrumPHP testsuites

### DIFF
--- a/grumphp.yml
+++ b/grumphp.yml
@@ -2,17 +2,6 @@ parameters:
   git_dir: .
   bin_dir: vendor/bin
 grumphp:
-  testsuites:
-    linters:
-      tasks:
-        - phplint
-        - yamllint
-        - jsonlint
-    code_quality:
-      tasks:
-        - phpcs
-        - phpmd
-        - twigcs
   ascii:
     failed: vendor/axelerant/drupal-quality-checker/resources/grumpy.txt
     succeeded: vendor/axelerant/drupal-quality-checker/resources/happy.txt


### PR DESCRIPTION
Removed testsuites from grumphp.yaml as we are using it in CI.