### PR TITLE
Delete platformsh env on PR Close

### DIFF
--- a/.github/actions/platformsh-clean-env/action.yml
+++ b/.github/actions/platformsh-clean-env/action.yml
@@ -1,0 +1,31 @@
+name: "Delele PR environments from platform.sh"
+description: "Set up platformsh CLI and clean PR env"
+inputs:
+  project-id:
+    description: "Project ID on platform.sh"
+    required: true
+  cli-token:
+    description: "Token for platform.sh CLI"
+    required: true
+  php-version:
+    description: "PHP version to setup for the CLI"
+    required: true
+    default: "8.1"
+runs:
+  using: "composite"
+  steps:
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+    - uses: adam7/platformsh-cli-action@v1.2
+      with:
+        token: ${{ inputs.cli-token }}
+    - run: ${{ github.action_path }}/script.sh
+      shell: bash
+      env:
+        PLATFORM_PROJECT_ID: ${{ inputs.project-id }}
+        PLATFORMSH_CLI_TOKEN: ${{ inputs.cli-token }}
+        PR_REF: "${{ github.event.pull_request.number }}/merge"
+branding:
+  icon: upload-cloud
+  color: orange

--- a/.github/actions/platformsh-clean-env/script.sh
+++ b/.github/actions/platformsh-clean-env/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+echo "PR_REF is $PR_REF"
+
+TYPE=$(platform environment:info --project $PLATFORM_PROJECT_ID --environment $PR_REF type)
+NAME=$(platform environment:info --project $PLATFORM_PROJECT_ID --environment $PR_REF name)
+
+
+echo "Enviroment type is $TYPE"
+echo "Environment name is $NAME"
+
+if [ "$TYPE" = "development" ] && [ -n "$NAME" ]; then
+  echo "Deactivating the env on platform.sh"
+  platform environment:delete --project $PLATFORM_PROJECT_ID $PR_REF -y
+else
+  echo "No env found for the PR on Platform.sh"
+fi

--- a/.github/actions/platformsh-clean-env/script.sh
+++ b/.github/actions/platformsh-clean-env/script.sh
@@ -11,7 +11,7 @@ echo "Environment name is $NAME"
 
 if [ "$TYPE" = "development" ] && [ -n "$NAME" ]; then
   echo "Deactivating the env on platform.sh"
-  platform environment:delete --project $PLATFORM_PROJECT_ID $PR_REF -y
+  platform environment:delete --project $PLATFORM_PROJECT_ID --delete-branch $PR_REF -y
 else
   echo "No env found for the PR on Platform.sh"
 fi

--- a/.github/workflows/clean-pr-env.yml
+++ b/.github/workflows/clean-pr-env.yml
@@ -1,0 +1,19 @@
+name: Clean Platform.sh env on PR Close
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  on-pr-close:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Clean Platform.sh env if available
+        uses: "./.github/actions/platformsh-clean-env"
+        with:
+          project-id: "brbqplxd7ycq6"
+          cli-token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}


### PR DESCRIPTION
Features:

1. includes a GitHub composite action to identify and delete platform.sh env if any. currently I have kept it on local only for testing. once we approve the changes, we can publish It as a separate GitHub action. 
2. a GitHub action to run on PR closed event and use above action