### PR TITLE
ci: enable force-push for deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,3 +169,4 @@ jobs:
         with:
           project-id: "brbqplxd7ycq6"
           cli-token: ${{ secrets.PLATFORMSH_CLI_TOKEN }}
+          force-push: true


### PR DESCRIPTION
Use `force-push` for deployment action