### PR TITLE
Concurrency issues with deployment and other pipelines

### DIFF
--- a/.github/workflows/vr.yml
+++ b/.github/workflows/vr.yml
@@ -9,7 +9,7 @@ on:
     - cron: '0 0 * * MON'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: vr-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
add `vr-` prefix to group key. This fixes issue #538 