### PR TITLE
chore: uninstall unnecessary jquery modules

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -44,10 +44,6 @@ module:
   history: 0
   image: 0
   inline_entity_form: 0
-  jquery_ui: 0
-  jquery_ui_datepicker: 0
-  jquery_ui_slider: 0
-  jquery_ui_touch_punch: 0
   jsonapi: 0
   language: 0
   layout_builder: 0


### PR DESCRIPTION
This is required before we can upgrade to Better Exposed Filters 7.0 which removes these modules.