### PR TITLE
chore: update do_username module

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2108,31 +2108,31 @@
         },
         {
             "name": "drupal/do_username",
-            "version": "2.0.0-beta4",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/do_username.git",
-                "reference": "2.0.0-beta4"
+                "reference": "2.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/do_username-2.0.0-beta4.zip",
-                "reference": "2.0.0-beta4",
-                "shasum": "b826092748a4c828147533ce418c2e5d2ccaa1f4"
+                "url": "https://ftp.drupal.org/files/projects/do_username-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "73f6c59dcda8a9da2fa8565bcb2bc9cd08ca4e91"
             },
             "require": {
-                "drupal/core": "^10",
+                "drupal/core": "^10 || ^11",
                 "hussainweb/drupal-api-client": "^2.1",
                 "php-http/guzzle7-adapter": "^1.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0-beta4",
-                    "datestamp": "1699891259",
+                    "version": "2.0.0",
+                    "datestamp": "1725553606",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -11196,16 +11196,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.1",
+            "version": "1.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d8ed7fffa66de1db0d2972267d8ed1d8fa0fe5a2"
+                "reference": "0ca1c7bb55fca8fe6448f16fff0f311ccec960a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d8ed7fffa66de1db0d2972267d8ed1d8fa0fe5a2",
-                "reference": "d8ed7fffa66de1db0d2972267d8ed1d8fa0fe5a2",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0ca1c7bb55fca8fe6448f16fff0f311ccec960a1",
+                "reference": "0ca1c7bb55fca8fe6448f16fff0f311ccec960a1",
                 "shasum": ""
             },
             "require": {
@@ -11250,7 +11250,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-03T19:55:22+00:00"
+            "time": "2024-09-05T16:09:28+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",


### PR DESCRIPTION
This updates the module to the latest release bringing in important fixes, including a fix for Drush 13 that's affecting #588.