### PR TITLE
fix: grumphp config is actually regex

### DIFF
--- a/grumphp.yml
+++ b/grumphp.yml
@@ -34,9 +34,9 @@ grumphp:
       standard:
         - phpcs.xml
       ignore_patterns:
-        - .github
-        - .gitlab
-        - .ddev
+        - /\.github
+        - /\.gitlab
+        - /\.ddev
         - /config
         - /drush
         - /web/robots.txt

--- a/web/modules/custom/ct_github/src/GithubRetriever.php
+++ b/web/modules/custom/ct_github/src/GithubRetriever.php
@@ -65,7 +65,7 @@ class GithubRetriever {
    */
   public function getIssues() {
     $userContributions = $this->getUserContributions($this->username);
-    if(!$userContributions){
+    if (!$userContributions) {
       return NULL;
     }
     $issues = array_map(function ($issue) {
@@ -79,7 +79,7 @@ class GithubRetriever {
    */
   public function getCodeContributions() {
     $userContributions = $this->getUserContributions($this->username);
-    if(!$userContributions){
+    if (!$userContributions) {
       return NULL;
     }
     $codeContribution = [];


### PR DESCRIPTION
GrumPHP's PHPCS was not scanning modules such as `ct_github` because of the ignore_pattern that said `.github`. It turns out that the pattern is actually regex and it was matching what we don't want.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
