### PR TITLE
fix: handle multiline output of missing config export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         if: ${{ !contains(steps.validate_config.outputs.status_output, 'No differences') }}
         run: |
           echo "::warning::Config export has differences"
-          echo ${{ steps.validate_config.outputs.status_output }}
+          echo "${{ steps.validate_config.outputs.status_output }}"
 
       - name: Deploy the site
         run: |


### PR DESCRIPTION
When multiple missing config exports are present, the output was being misinterpreted as shell commands, leading to errors during step execution.