### PR TITLE
chore: switch to Node 22

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -18,7 +18,6 @@ web_environment:
     - PLATFORM_PROJECT=brbqplxd7ycq6
 corepack_enable: false
 ddev_version_constraint: ">= 1.23.3" # We need this for MariaDB 11.4 compatibility.
-nodejs_version: "20"
 
 # Key features of DDEV's config.yaml:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
   frontend_codequality:
     runs-on: ubuntu-latest
-    container: node:20
+    container: node:lts
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -140,7 +140,7 @@ hooks:
     build: |
       set -e
       # Install the latest lts
-      n 20
+      n lts
       # Reset the location hash to recognize the newly installed version
       hash -r
 

--- a/web/themes/custom/contribtracker/gulpfile.js
+++ b/web/themes/custom/contribtracker/gulpfile.js
@@ -2,7 +2,7 @@ import gulp from 'gulp';
 import config from './gulp-tasks/config.js';
 
 import scss from './gulp-tasks/scss.js';
-import ts from './gulp-tasks/ts.js'
+import ts from './gulp-tasks/ts.js';
 import svg from './gulp-tasks/svg.js';
 import pretty from './gulp-tasks/prettier.js';
 import lint from './gulp-tasks/lint.js';

--- a/web/themes/custom/contribtracker/package-lock.json
+++ b/web/themes/custom/contribtracker/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "contribtracker",
       "version": "1.0.0",
       "dependencies": {
         "select2": "^4.1.0-rc.0"


### PR DESCRIPTION
This PR won't work because of the gulp tasks that use `gulp-imagemin` and `gulp-svgstore`. Removing the tasks `svg` and `images` can help this pass but we have to consider if this is going to be fixed in the upstream packages. There is not much hope for `gulp-svgstore` as it is 3 years old already. There is some activity on `imagemin` and it might eventually work with that. That said, there is no obvious usage of `require` in the imagemin code.