### PR TITLE
test: temporarily disable test for Twitter link redirect

### DIFF
--- a/web/themes/custom/contribtracker/cypress/e2e/social-media-link-check.cy.js
+++ b/web/themes/custom/contribtracker/cypress/e2e/social-media-link-check.cy.js
@@ -3,6 +3,7 @@ describe('Social Media Icons Redirection Validation', { tags: ['critical-path'] 
   // List of social media icons with their selectors
   const socialMediaLinks = [
     { selector: '.icon-facebook' },
+    // See https://github.com/contrib-tracker/backend/pull/716
     // { selector: '.icon-twitter' },
     { selector: '.icon-linkedin' },
   ];

--- a/web/themes/custom/contribtracker/cypress/e2e/social-media-link-check.cy.js
+++ b/web/themes/custom/contribtracker/cypress/e2e/social-media-link-check.cy.js
@@ -3,7 +3,7 @@ describe('Social Media Icons Redirection Validation', { tags: ['critical-path'] 
   // List of social media icons with their selectors
   const socialMediaLinks = [
     { selector: '.icon-facebook' },
-    { selector: '.icon-twitter' },
+    // { selector: '.icon-twitter' },
     { selector: '.icon-linkedin' },
   ];
 


### PR DESCRIPTION
The social media links check test fails on HEAD right now. Twitter has apparently changed how people can view its pages while not logged in. For some weird reason, this breaks the redirection logic in the test.

This leads me to wonder why we have that particular test in the first place. Why do we care if the redirect is happening in a certain way?! If the URL returns 2xx or 3xx, we should be happy, IMHO. @KosalaiV, can you explain the rationale of this test? cc @Truptii 