### PR TITLE
fix: broken build because gulp

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -18,7 +18,7 @@ web_environment:
     - PLATFORM_PROJECT=brbqplxd7ycq6
 corepack_enable: false
 ddev_version_constraint: ">= 1.23.3" # We need this for MariaDB 11.4 compatibility.
-nodejs_version: "20"
+nodejs_version: "18"
 
 # Key features of DDEV's config.yaml:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
   frontend_codequality:
     runs-on: ubuntu-latest
-    container: node:20
+    container: node:18
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -184,8 +184,8 @@ jobs:
       - name: Build front-end
         run: |
           cd web/themes/custom/contribtracker
-          npm ci  --prefer-offline --no-audit
-          gulp
+          ddev npm ci  --prefer-offline --no-audit
+          ddev npm run build
 
       - name: Run phpstan
         run: ddev php ./vendor/bin/grumphp run --tasks=phpstan --no-interaction


### PR DESCRIPTION
I tested with various Node versions and it seems that the only way is to go all the way back to NodeJs 18.
