### PR TITLE
fix: broken GitHub scanning

### DIFF
--- a/web/modules/custom/ct_github/src/GithubQuery.php
+++ b/web/modules/custom/ct_github/src/GithubQuery.php
@@ -43,8 +43,11 @@ class GithubQuery {
   public function __construct(ConfigFactory $config_factory, CacheBackendInterface $cacheBackend) {
     $config = $config_factory->get('ct_github.settings');
     $token = $config->get('github_auth_token');
-    $client = (strlen($token) >= 40) ? (new Client())->authenticate($token, NULL, AuthMethod::ACCESS_TOKEN) : NULL;
-    $this->client = $client;
+    $this->client = NULL;
+    if (strlen($token) >= 40) {
+      $this->client = new Client();
+      $this->client->authenticate(tokenOrLogin: $token, authMethod: AuthMethod::ACCESS_TOKEN);
+    }
     $this->cache = $cacheBackend;
   }
 


### PR DESCRIPTION
This broke sometime back in November (in #662) and the fix was staring right in my face, but I didn't catch it. The change resulted in `client` always being set to NULL (because the authenticate method returns NULL). This PR fixes it by breaking the assignment and function call on different lines.
